### PR TITLE
Update README.md

### DIFF
--- a/plugin/metrics/README.md
+++ b/plugin/metrics/README.md
@@ -1,12 +1,12 @@
-# prometheus
+# metrics
 
 ## Name
 
-*prometheus* - enables [Prometheus](https://prometheus.io/) metrics.
+*metrics* - enables [Prometheus](https://prometheus.io/) metrics.
 
 ## Description
 
-With *prometheus* you export metrics from CoreDNS and any plugin that has them.
+With *metrics* you export metrics from CoreDNS and any plugin that has them.
 The default location for the metrics is `localhost:9153`. The metrics path is fixed to `/metrics`.
 The following metrics are exported:
 


### PR DESCRIPTION
Updated readme file which still called this plugin `prometheus` instead of `metrics`.

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Documentation does not match plugin name.
### 2. Which issues (if any) are related?
None
### 3. Which documentation changes (if any) need to be made?
None
### 4. Does this introduce a backward incompatible change or deprecation?
None